### PR TITLE
Automate more release steps

### DIFF
--- a/.github/workflows/prepare-release-add-on.yml
+++ b/.github/workflows/prepare-release-add-on.yml
@@ -1,0 +1,21 @@
+name: Prepare Release Add-on
+
+on:
+  workflow_dispatch:
+
+jobs:
+  prepare-release:
+    name: Prepare Release
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Setup Java
+      uses: actions/setup-java@v1
+      with:
+        java-version: 8
+    - name: Prepare Release and Create Pull Request
+      env:
+        ZAPBOT_TOKEN: ${{ secrets.ZAPBOT_TOKEN }}
+      run: ./gradlew createPullRequestRelease

--- a/.github/workflows/release-add-on.yml
+++ b/.github/workflows/release-add-on.yml
@@ -2,20 +2,26 @@ name: Release Add-On
 
 on:
   push:
-    tags:
-      - 'v*'
+    branches:
+      - main
+    paths:
+      - 'gradle.properties'
 
 jobs:
   release:
     name: Build and Release Add-On
-    if: github.actor == 'kingthorin' || github.actor == 'psiinon' || github.actor == 'thc202'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - name: Build and Release Add-On
-      uses: docker://openjdk:8
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - uses: actions/checkout@v2
       with:
-        entrypoint: ./gradlew
-        args: createReleaseFromGitHubRef
+        fetch-depth: 0
+    - name: Setup Java
+      uses: actions/setup-java@v1
+      with:
+        java-version: 8
+    - name: Generate Release State
+      run: ./gradlew generateReleaseStateLastCommit
+    - name: Build and Release Add-On
+      env:
+        ZABOT_TOKEN: ${{ secrets.ZABOT_TOKEN }}
+      run: ./gradlew releaseAddOn

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,9 @@
+# Release
+
+The following steps should be followed to release the add-on:
+ 1. Run the workflow [Prepare Release Add-on](https://github.com/zaproxy/fuzzdb-offensive/actions/workflows/prepare-release-add-on.yml),
+    to prepare the release. It creates a pull request updating the version and changelog;
+ 2. Merge the pull request.
+
+After merging the pull request the [Release Add-on](https://github.com/zaproxy/fuzzdb-offensive/actions/workflows/release-add-on.yml) workflow
+will create the tag, create the release, trigger the update of the marketplace, and create a pull request preparing the next development iteration.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,14 +1,14 @@
-import org.zaproxy.gradle.addon.AddOnPlugin
 import org.zaproxy.gradle.addon.AddOnStatus
+import org.zaproxy.gradle.addon.internal.model.ProjectInfo
+import org.zaproxy.gradle.addon.internal.model.ReleaseState
+import org.zaproxy.gradle.addon.internal.tasks.GenerateReleaseStateLastCommit
 import org.zaproxy.gradle.addon.misc.ConvertMarkdownToHtml
-import org.zaproxy.gradle.addon.misc.CreateGitHubRelease
-import org.zaproxy.gradle.addon.misc.ExtractLatestChangesFromChangelog
 
 plugins {
     `java-library`
     eclipse
     id("com.diffplug.spotless") version "5.12.1"
-    id("org.zaproxy.add-on") version "0.5.0"
+    id("org.zaproxy.add-on") version "0.6.0"
 }
 
 eclipse {
@@ -22,7 +22,6 @@ repositories {
     mavenCentral()
 }
 
-version = "4"
 description = "FuzzDB web backdoors and attack files which can be used with the ZAP fuzzer or for manual penetration testing"
 
 java {
@@ -58,33 +57,15 @@ spotless {
     }
 }
 
-System.getenv("GITHUB_REF")?.let { ref ->
-    if ("refs/tags/" !in ref) {
-        return@let
-    }
+val projectInfo = ProjectInfo.from(project)
+val generateReleaseStateLastCommit by tasks.registering(GenerateReleaseStateLastCommit::class) {
+    projects.set(listOf(projectInfo))
+}
 
-    tasks.register<CreateGitHubRelease>("createReleaseFromGitHubRef") {
-        val targetTag = ref.removePrefix("refs/tags/")
-        val targetAddOnVersion = targetTag.removePrefix("v")
-
-        authToken.set(System.getenv("GITHUB_TOKEN"))
-        repo.set(System.getenv("GITHUB_REPOSITORY"))
-        tag.set(targetTag)
-
-        title.set(provider { "v${zapAddOn.addOnVersion.get()}" })
-        bodyFile.set(tasks.named<ExtractLatestChangesFromChangelog>("extractLatestChanges").flatMap { it.latestChanges })
-
-        assets {
-            register("add-on") {
-                file.set(tasks.named<Jar>(AddOnPlugin.JAR_ZAP_ADD_ON_TASK_NAME).flatMap { it.archiveFile })
-            }
-        }
-
-        doFirst {
-            val addOnVersion = zapAddOn.addOnVersion.get()
-            require(addOnVersion == targetAddOnVersion) {
-                "Version of the tag $targetAddOnVersion does not match the version of the add-on $addOnVersion"
-            }
-        }
+val releaseAddOn by tasks.registering {
+    if (ReleaseState.read(projectInfo).isNewRelease()) {
+        dependsOn("createRelease")
+        dependsOn("handleRelease")
+        dependsOn("createPullRequestNextDevIter")
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+version=4
+release=false


### PR DESCRIPTION
Add workflow to prepare the release.
Tweak existing workflow to do the release on merge.
Move version (and add release state) to a properties file to ease the
automation.
Update Gradle add-on plugin and build for the release automation.
Document steps to release the add-on.