### PR TITLE
Don't persist credentials in release workflows

### DIFF
--- a/.github/workflows/prepare-release-add-on.yml
+++ b/.github/workflows/prepare-release-add-on.yml
@@ -11,6 +11,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        persist-credentials: false
     - name: Setup Java
       uses: actions/setup-java@v1
       with:

--- a/.github/workflows/release-add-on.yml
+++ b/.github/workflows/release-add-on.yml
@@ -15,6 +15,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        persist-credentials: false
     - name: Setup Java
       uses: actions/setup-java@v1
       with:


### PR DESCRIPTION
Do not persist the default credentials in release workflows as it's
causing a conflict with jgit (which should be using zapbot credentials).